### PR TITLE
L1 averaged over batch

### DIFF
--- a/sparse_autoencoder/autoencoder/loss.py
+++ b/sparse_autoencoder/autoencoder/loss.py
@@ -1,6 +1,6 @@
 """Loss function for the Sparse Autoencoder."""
-import torch
 from jaxtyping import Float
+import torch
 from torch import Tensor
 from torch.nn.functional import mse_loss
 

--- a/sparse_autoencoder/autoencoder/loss.py
+++ b/sparse_autoencoder/autoencoder/loss.py
@@ -88,4 +88,4 @@ def sae_training_loss(
         Overall training loss.
     """
     total_loss = reconstruction_loss_mse + l1_loss_learned_activations * l1_coefficient
-    return total_loss.sum()
+    return total_loss

--- a/sparse_autoencoder/autoencoder/loss.py
+++ b/sparse_autoencoder/autoencoder/loss.py
@@ -48,9 +48,9 @@ def l1_loss(learned_activations: Float[Tensor, "*batch learned_activations"]) ->
         learned_activations: Activations from the hidden layer.
 
     Returns:
-        L1 loss on learned activations.
+        L1 loss on learned activations, summed over the last dimension and averaged over all other elements.
     """
-    return torch.abs(learned_activations).sum(dim=-1)
+    return torch.abs(learned_activations).sum(dim=-1).mean()
 
 
 def sae_training_loss(

--- a/sparse_autoencoder/autoencoder/loss.py
+++ b/sparse_autoencoder/autoencoder/loss.py
@@ -1,6 +1,6 @@
 """Loss function for the Sparse Autoencoder."""
-from jaxtyping import Float
 import torch
+from jaxtyping import Float
 from torch import Tensor
 from torch.nn.functional import mse_loss
 
@@ -42,7 +42,7 @@ def l1_loss(learned_activations: Float[Tensor, "*batch learned_activations"]) ->
     Examples:
     >>> learned_activations = torch.tensor([[2.0, -3]])
     >>> l1_loss(learned_activations)
-    tensor([5.])
+    tensor(5.)
 
     Args:
         learned_activations: Activations from the hidden layer.

--- a/sparse_autoencoder/autoencoder/loss.py
+++ b/sparse_autoencoder/autoencoder/loss.py
@@ -75,7 +75,7 @@ def sae_training_loss(
         >>> l1_loss_learned_activations = torch.tensor([1.])
         >>> l1_coefficient = 0.5
         >>> sae_training_loss(reconstruction_loss_mse, l1_loss_learned_activations, l1_coefficient)
-        tensor(3.)
+        tensor([3.])
 
     Args:
         reconstruction_loss_mse: MSE reconstruction loss.

--- a/sparse_autoencoder/autoencoder/loss.py
+++ b/sparse_autoencoder/autoencoder/loss.py
@@ -48,7 +48,8 @@ def l1_loss(learned_activations: Float[Tensor, "*batch learned_activations"]) ->
         learned_activations: Activations from the hidden layer.
 
     Returns:
-        L1 loss on learned activations, summed over the last dimension and averaged over all other elements.
+        L1 loss on learned activations,
+        summed over the last dimension and averaged over all other elements.
     """
     return torch.abs(learned_activations).sum(dim=-1).mean()
 
@@ -87,5 +88,4 @@ def sae_training_loss(
     Returns:
         Overall training loss.
     """
-    total_loss = reconstruction_loss_mse + l1_loss_learned_activations * l1_coefficient
-    return total_loss
+    return reconstruction_loss_mse + l1_loss_learned_activations * l1_coefficient


### PR DESCRIPTION
[This line](https://github.com/ai-safety-foundation/sparse_autoencoder/blob/main/sparse_autoencoder/autoencoder/loss.py#L91) broadcasted the scalar MSE across all batch dimensions of the L1. The L1 was also logged to wandb as a tensor. This PR means the L1 is averaged over all initial dimensions and also removes the `.sum()` that hid this error 