### PR TITLE
Restrict Python version to <3.12 due to aiohttp compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -342,9 +342,6 @@ files = [
     {file = "Babel-2.13.1.tar.gz", hash = "sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900"},
 ]
 
-[package.dependencies]
-setuptools = {version = "*", markers = "python_version >= \"3.12\""}
-
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
@@ -2272,7 +2269,6 @@ files = [
 numpy = [
     {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
-    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3930,10 +3926,7 @@ datasets = ">=2.7.1"
 einops = ">=0.6.0"
 fancy-einsum = ">=0.0.3"
 jaxtyping = ">=0.2.11"
-numpy = [
-    {version = ">=1.24", markers = "python_version >= \"3.9\" and python_version < \"3.12\""},
-    {version = ">=1.26", markers = "python_version >= \"3.12\" and python_version < \"3.13\""},
-]
+numpy = {version = ">=1.24", markers = "python_version >= \"3.9\" and python_version < \"3.12\""}
 nvidia-cublas-cu12 = {version = ">=12.1.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cuda-cupti-cu12 = {version = ">=12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 nvidia-cuda-nvrtc-cu12 = {version = ">=12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
@@ -4515,5 +4508,5 @@ cffi = ["cffi (>=1.11)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10, <3.13"
-content-hash = "370f47f4e7f6b3452dda4d5bb40fd1de35da6241767c1800b7e847069ac9e531"
+python-versions = ">=3.10, <3.12"
+content-hash = "0bfaf42edae6228f501176fcbd7e8af2072c0cfa2b31fc7faf37b8d9d9f6dc7b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
     [tool.poetry.dependencies]
         einops=">=0.6"
-        python=">=3.10, <3.13"
+        python=">=3.10, <3.12"
         torch=">=2.1"
         wandb=">=0.15.12"
         zstandard="^0.22.0"    # Required for downloading datasets such as The Pile


### PR DESCRIPTION
PR updates the Python version constraint in pyproject.toml to exclude Python 3.12, where aiohttp version 3.8.1 has compatibility issues.

Modified the Python version requirement from python=">=3.10, <3.13" to python=">=3.10, <3.12" in pyproject.toml.