### PR TITLE
Remove constrained unit norm from encoder weights

### DIFF
--- a/sparse_autoencoder/autoencoder/model.py
+++ b/sparse_autoencoder/autoencoder/model.py
@@ -2,7 +2,7 @@
 from jaxtyping import Float
 import torch
 from torch import Tensor
-from torch.nn import Module, ReLU, Sequential
+from torch.nn import Linear, Module, ReLU, Sequential
 from torch.nn.parameter import Parameter
 
 from sparse_autoencoder.autoencoder.components.tied_bias import TiedBias, TiedBiasPosition
@@ -74,9 +74,7 @@ class SparseAutoencoder(Module):
         # Create the network
         self.encoder = Sequential(
             TiedBias(self.tied_bias, TiedBiasPosition.PRE_ENCODER),
-            ConstrainedUnitNormLinear(
-                n_input_features, n_learned_features, bias=True, device=device, dtype=dtype
-            ),
+            Linear(n_input_features, n_learned_features, bias=True, device=device, dtype=dtype),
             ReLU(),
         )
 

--- a/sparse_autoencoder/autoencoder/tests/snapshots/snap_test_model.py
+++ b/sparse_autoencoder/autoencoder/tests/snapshots/snap_test_model.py
@@ -8,7 +8,7 @@ snapshots = Snapshot()
 snapshots["test_representation Model string representation"] = """SparseAutoencoder(
   (encoder): Sequential(
     (0): TiedBias(position=pre_encoder)
-    (1): ConstrainedUnitNormLinear(in_features=3, out_features=6, bias=True)
+    (1): Linear(in_features=3, out_features=6, bias=True)
     (2): ReLU()
   )
   (decoder): Sequential(

--- a/sparse_autoencoder/autoencoder/tests/snapshots/snap_test_model.py
+++ b/sparse_autoencoder/autoencoder/tests/snapshots/snap_test_model.py
@@ -1,4 +1,4 @@
-"""Auto-Generated Snapshottest File."""
+"""Auto-Generated Snapshot tests."""
 
 from snapshottest import Snapshot
 


### PR DESCRIPTION
This should only be on the decoder. Thanks to @HoagyC for pointing this out.