### PR TITLE
Add Metric abstraction so metrics can be added to pipeline

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -194,6 +194,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
+                "# import wandb\n",
                 "# wandb.init(project=\"sparse-autoencoder\", dir=\".cache/wandb\")"
             ]
         },

--- a/sparse_autoencoder/train/metrics/capacity.py
+++ b/sparse_autoencoder/train/metrics/capacity.py
@@ -8,6 +8,8 @@ import torch
 from torch import Tensor
 import wandb
 
+from sparse_autoencoder.train.metrics.metric_class import Metric, MetricArgs
+
 
 def calc_capacities(features: Float[Tensor, "n_feats feat_dim"]) -> Float[Tensor, " n_feats"]:
     """Calculate capacities.
@@ -62,3 +64,13 @@ def wandb_capacities_histogram(
 
     bins, values = histogram(numpy_capacities, bins=20, range=(0, 1))
     return wandb.Histogram(np_histogram=(bins, values))
+
+
+class CapacityMetric(Metric):
+    """Capacity metric."""
+
+    def compute_and_log(self, args: MetricArgs) -> None:
+        """Compute and log the capacity of the learned features."""
+        value = calc_capacities(args["autoencoder"].decoder[0].weight)
+        histogram = wandb_capacities_histogram(value)
+        wandb.log({"capacities_histogram": histogram})

--- a/sparse_autoencoder/train/metrics/capacity.py
+++ b/sparse_autoencoder/train/metrics/capacity.py
@@ -73,4 +73,4 @@ class CapacityMetric(Metric):
         """Compute and log the capacity of the learned features."""
         value = calc_capacities(args["autoencoder"].decoder[0].weight)
         histogram = wandb_capacities_histogram(value)
-        wandb.log({"capacities_histogram": histogram})
+        wandb.log({"capacities_histogram": histogram}, step=args["step"], commit=False)

--- a/sparse_autoencoder/train/metrics/feature_density.py
+++ b/sparse_autoencoder/train/metrics/feature_density.py
@@ -1,5 +1,4 @@
 """Feature density metrics & histogram."""
-
 import einops
 from jaxtyping import Float
 from numpy import histogram
@@ -68,7 +67,5 @@ class FeatureDensityMetric(Metric):
     def compute_and_log(self, args: MetricArgs) -> None:
         """Compute and log the feature density histogram."""
         value = calc_feature_density(args["learned_activations"])
-
         histogram = wandb_feature_density_histogram(value)
-
-        wandb.log({"feature_density_histogram": histogram})
+        wandb.log({"feature_density_histogram": histogram}, step=args["step"], commit=False)

--- a/sparse_autoencoder/train/metrics/metric_class.py
+++ b/sparse_autoencoder/train/metrics/metric_class.py
@@ -1,0 +1,30 @@
+"""Base class for metrics."""
+from abc import ABC, abstractmethod
+from typing import TypedDict
+
+from jaxtyping import Float
+from torch import Tensor
+from torch.optim import Optimizer
+
+from sparse_autoencoder.autoencoder.model import SparseAutoencoder
+
+
+class MetricArgs(TypedDict):
+    """Class to hold arguments to metrics, contains everything needed to compute any metric."""
+
+    step: int
+    batch: Float[Tensor, "batch input_activations"]
+    reconstruction_loss_mse: Float[Tensor, " item"]
+    l1_loss: Float[Tensor, " item"]
+    autoencoder: SparseAutoencoder
+    optimizer: Optimizer
+    learned_activations: Float[Tensor, "batch learned_activations"]
+    reconstructed_activations: Float[Tensor, "batch input_activations"]
+
+
+class Metric(ABC):
+    """Base class for metrics."""
+
+    @abstractmethod
+    def compute_and_log(self, args: MetricArgs) -> None:
+        """Compute the metric value."""

--- a/sparse_autoencoder/train/train_autoencoder.py
+++ b/sparse_autoencoder/train/train_autoencoder.py
@@ -101,9 +101,9 @@ def train_autoencoder(
                         "loss": total_loss.mean().item(),
                     },
                     commit=False,
+                    step=step + previous_steps + 1,
                 )
 
-            # TODO: Get the feature density & also log to wandb
             metric_args = MetricArgs(
                 step=step + previous_steps + 1,
                 batch=batch,


### PR DESCRIPTION
Tries to create a flexible metrics abstraction that ensures that additional metrics don't clog the train loop and which allows users of the library to pass their own metrics into the train loop without having to edit the library itself.

Changes:

- Implemented a new base Metric class.
- Converted existing metrics to subclasses of Metric.
- Introduced MetricArgs TypedDict for passing generic metric args to 
- Integrated these changes into the training loop.
- New metrics can be added by users with the `additional_metrics` argument to `pipeline`.
