### PR TITLE
Add flexibility to resampler and move resampling logic inside resampler.

### DIFF
--- a/docs/content/demo.ipynb
+++ b/docs/content/demo.ipynb
@@ -324,7 +324,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "activation_resampler = ActivationResampler()"
+    "activation_resampler = ActivationResampler(\n",
+    "    resample_interval=10_000,\n",
+    "    n_steps_collate=10_000,\n",
+    "    max_resamples=5\n",
+    ")"
    ]
   },
   {
@@ -348,10 +352,24 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "34ec5759e3434d23b7d08aef82a17c71",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading readme:   0%|          | 0.00/946 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/alan/Documents/Repos/sparse_autoencoder/.venv/lib/python3.11/site-packages/huggingface_hub/repocard.py:105: UserWarning: Repo card metadata block was not found. Setting CardData to empty.\n",
+      "/Users/hoagycunningham/sparse_autoencoder/.venv/lib/python3.10/site-packages/huggingface_hub/repocard.py:105: UserWarning: Repo card metadata block was not found. Setting CardData to empty.\n",
       "  warnings.warn(\"Repo card metadata block was not found. Setting CardData to empty.\")\n"
      ]
     }
@@ -388,8 +406,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Failed to detect the name of this notebook, you can set it manually with the WANDB_NOTEBOOK_NAME environment variable to enable code saving.\n",
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33malan-cooney\u001b[0m. Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n"
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mhoagy\u001b[0m (\u001b[33mdistillrepr\u001b[0m). Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n"
      ]
     },
     {
@@ -407,7 +424,7 @@
     {
      "data": {
       "text/html": [
-       "Run data is saved locally in <code>.cache/wandb/run-20231122_191929-kc45kj7w</code>"
+       "Run data is saved locally in <code>.cache/wandb/run-20231123_114419-wcjmy7jd</code>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -419,7 +436,7 @@
     {
      "data": {
       "text/html": [
-       "Syncing run <strong><a href='https://wandb.ai/alan-cooney/sparse-autoencoder/runs/kc45kj7w' target=\"_blank\">young-frog-69</a></strong> to <a href='https://wandb.ai/alan-cooney/sparse-autoencoder' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/run' target=\"_blank\">docs</a>)<br/>"
+       "Syncing run <strong><a href='https://wandb.ai/distillrepr/sparse-autoencoder/runs/wcjmy7jd' target=\"_blank\">dulcet-puddle-72</a></strong> to <a href='https://wandb.ai/distillrepr/sparse-autoencoder' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/run' target=\"_blank\">docs</a>)<br/>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -431,7 +448,7 @@
     {
      "data": {
       "text/html": [
-       " View project at <a href='https://wandb.ai/alan-cooney/sparse-autoencoder' target=\"_blank\">https://wandb.ai/alan-cooney/sparse-autoencoder</a>"
+       " View project at <a href='https://wandb.ai/distillrepr/sparse-autoencoder' target=\"_blank\">https://wandb.ai/distillrepr/sparse-autoencoder</a>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -443,7 +460,7 @@
     {
      "data": {
       "text/html": [
-       " View run at <a href='https://wandb.ai/alan-cooney/sparse-autoencoder/runs/kc45kj7w' target=\"_blank\">https://wandb.ai/alan-cooney/sparse-autoencoder/runs/kc45kj7w</a>"
+       " View run at <a href='https://wandb.ai/distillrepr/sparse-autoencoder/runs/wcjmy7jd' target=\"_blank\">https://wandb.ai/distillrepr/sparse-autoencoder/runs/wcjmy7jd</a>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -455,10 +472,10 @@
     {
      "data": {
       "text/html": [
-       "<button onClick=\"this.nextSibling.style.display='block';this.style.display='none';\">Display W&B run</button><iframe src='https://wandb.ai/alan-cooney/sparse-autoencoder/runs/kc45kj7w?jupyter=true' style='border:none;width:100%;height:420px;display:none;'></iframe>"
+       "<button onClick=\"this.nextSibling.style.display='block';this.style.display='none';\">Display W&B run</button><iframe src='https://wandb.ai/distillrepr/sparse-autoencoder/runs/wcjmy7jd?jupyter=true' style='border:none;width:100%;height:420px;display:none;'></iframe>"
       ],
       "text/plain": [
-       "<wandb.sdk.wandb_run.Run at 0x2fd4168d0>"
+       "<wandb.sdk.wandb_run.Run at 0x17582fb80>"
       ]
      },
      "execution_count": 9,
@@ -481,7 +498,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint_path = Path(\"../../.checkpoints\")\n",
+    "checkpoint_path = Path(\"../.checkpoints\")\n",
     "checkpoint_path.mkdir(exist_ok=True)"
    ]
   },
@@ -493,7 +510,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ced99fd678ab45a397fc785693c4321b",
+       "model_id": "3ae0882a6b2c4541901ac456a92b1d34",
        "version_major": 2,
        "version_minor": 0
       },
@@ -508,7 +525,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/alan/Documents/Repos/sparse_autoencoder/.venv/lib/python3.11/site-packages/torch/autograd/__init__.py:251: UserWarning: The operator 'aten::sgn.out' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/mps/MPSFallback.mm:13.)\n",
+      "/Users/hoagycunningham/sparse_autoencoder/.venv/lib/python3.10/site-packages/torch/autograd/__init__.py:251: UserWarning: The operator 'aten::sgn.out' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/mps/MPSFallback.mm:13.)\n",
       "  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass\n"
      ]
     }
@@ -532,7 +549,6 @@
     "    max_store_size=100_000,\n",
     "    # Sizes for demo purposes (you probably want to scale these by 10x)\n",
     "    max_activations=10_000_000,\n",
-    "    resample_frequency=100_000,\n",
     "    checkpoint_frequency=100_000,\n",
     ")"
    ]
@@ -543,9 +559,16 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "wandb: WARNING Source type is set to 'repo' but some required information is missing from the environment. A job will not be created from this run. See https://docs.wandb.ai/guides/launch/create-job\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "68abb0f22da047e18a4364c76ef06ba7",
+       "model_id": "b5203dd4bff14d32b919e33a0dbfb65c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -557,13 +580,6 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "wandb: WARNING Source type is set to 'repo' but some required information is missing from the environment. A job will not be created from this run. See https://docs.wandb.ai/guides/launch/create-job\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<style>\n",
@@ -571,7 +587,7 @@
        "    .wandb-row { display: flex; flex-direction: row; flex-wrap: wrap; justify-content: flex-start; width: 100% }\n",
        "    .wandb-col { display: flex; flex-direction: column; flex-basis: 100%; flex: 1; padding: 10px; }\n",
        "    </style>\n",
-       "<div class=\"wandb-row\"><div class=\"wandb-col\"><h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>LearnedActivationsL1Loss</td><td>█▃▁▁▁▂▁▂▁▃▃▂▄▄▅▄▅▆▆▇▄▂▄▂▃▃▂▂▃▃▃▅▃▂▄▄▃▄▇▇</td></tr><tr><td>LossReducer</td><td>█▃▂▁▁▁▁▂▁▃▃▂▃▃▅▄▄▅▅▆▄▂▃▂▃▂▂▂▂▂▃▄▄▂▅▄▃▃▆▆</td></tr><tr><td>MSEReconstructionLoss</td><td>█▄▄▂▁▁▁▁▁▂▂▂▂▂▄▃▃▂▃▃▂▃▁▂▂▁▁▁▂▁▄▁▄▁▇▂▁▃▂▃</td></tr></table><br/></div><div class=\"wandb-col\"><h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>LearnedActivationsL1Loss</td><td>0.00548</td></tr><tr><td>LossReducer</td><td>0.02247</td></tr><tr><td>MSEReconstructionLoss</td><td>0.01698</td></tr></table><br/></div></div>"
+       "<div class=\"wandb-row\"><div class=\"wandb-col\"><h3>Run history:</h3><br/><table class=\"wandb\"><tr><td>LearnedActivationsL1Loss</td><td>▆▂▁▁▁▂▁▂▁▃▃▂▃▄▄▃▅▃▅▆▆▄▂▃▃▃▃▂▄▃▃█▃▄▃▅▂▄▃▄</td></tr><tr><td>LossReducer</td><td>█▃▂▁▁▂▁▂▁▃▂▂▃▅▄▃▅▃▅▆▆▅▃▃▃▂▄▂▄▂▄█▄▄▃▆▂▅▃▄</td></tr><tr><td>MSEReconstructionLoss</td><td>█▄▃▂▁▁▂▂▁▁▁▂▂▅▂▃▂▂▃▂▃▅▃▁▁▁▂▁▁▁▄▂▄▁▃▃▁▃▃▁</td></tr></table><br/></div><div class=\"wandb-col\"><h3>Run summary:</h3><br/><table class=\"wandb\"><tr><td>LearnedActivationsL1Loss</td><td>0.00367</td></tr><tr><td>LossReducer</td><td>0.02043</td></tr><tr><td>MSEReconstructionLoss</td><td>0.01676</td></tr></table><br/></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -583,7 +599,7 @@
     {
      "data": {
       "text/html": [
-       " View run <strong style=\"color:#cdcd00\">young-frog-69</strong> at: <a href='https://wandb.ai/alan-cooney/sparse-autoencoder/runs/kc45kj7w' target=\"_blank\">https://wandb.ai/alan-cooney/sparse-autoencoder/runs/kc45kj7w</a><br/>Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)"
+       " View run <strong style=\"color:#cdcd00\">dulcet-puddle-72</strong> at: <a href='https://wandb.ai/distillrepr/sparse-autoencoder/runs/wcjmy7jd' target=\"_blank\">https://wandb.ai/distillrepr/sparse-autoencoder/runs/wcjmy7jd</a><br/>Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -595,7 +611,7 @@
     {
      "data": {
       "text/html": [
-       "Find logs at: <code>.cache/wandb/run-20231122_191929-kc45kj7w/logs</code>"
+       "Find logs at: <code>.cache/wandb/run-20231123_114419-wcjmy7jd/logs</code>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -654,7 +670,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.13 (main, Nov  1 2023, 16:33:59) [Clang 14.0.0 (clang-1400.0.29.202)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31186ba1239ad81afeb3c631b4833e71f34259d3b92eebb37a9091b916e08620"
+   }
   }
  },
  "nbformat": 4,

--- a/sparse_autoencoder/activation_resampler/abstract_activation_resampler.py
+++ b/sparse_autoencoder/activation_resampler/abstract_activation_resampler.py
@@ -2,7 +2,6 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import final
 
 from sparse_autoencoder.activation_store.tensor_store import TensorActivationStore
 from sparse_autoencoder.autoencoder.model import SparseAutoencoder
@@ -42,19 +41,33 @@ class AbstractActivationResampler(ABC):
     If none, will use the train dataset size.
     """
 
-    @final
-    def __init__(self, resample_dataset_size: int | None = None) -> None:
-        """Initialize the abstract activation resampler.
+    @abstractmethod
+    def step_resampler(
+        self,
+        last_resampled: int,
+        batch_neuron_activity: NeuronActivity,
+        activation_store: TensorActivationStore,
+        autoencoder: SparseAutoencoder,
+        loss_fn: AbstractLoss,
+        train_batch_size: int,
+    ) -> ParameterUpdateResults | None:
+        """Resample dead neurons.
 
         Args:
-            resample_dataset_size: Resample dataset size. If none, will use the train dataset size.
+            last_resampled: Number of steps since last resampled.
+            batch_neuron_activity: Number of times each neuron fired in current batch.
+            activation_store: Activation store.
+            autoencoder: Sparse autoencoder model.
+            loss_fn: Loss function.
+            train_batch_size: Train batch size (also used for resampling).
+
+        Returns:
+            Indices of dead neurons, and the updates for the encoder and decoder weights and biases.
         """
-        self._resample_dataset_size = resample_dataset_size
 
     @abstractmethod
     def resample_dead_neurons(
         self,
-        neuron_activity: NeuronActivity,
         activation_store: TensorActivationStore,
         autoencoder: SparseAutoencoder,
         loss_fn: AbstractLoss,
@@ -63,7 +76,6 @@ class AbstractActivationResampler(ABC):
         """Resample dead neurons.
 
         Args:
-            neuron_activity: Number of times each neuron fired.
             activation_store: Activation store.
             autoencoder: Sparse autoencoder model.
             loss_fn: Loss function.


### PR DESCRIPTION
Moves the activation collection logic into the resampler class and adds three parameters to the resampler class to allow and adds three `__init__` parameters. These are 
* `resample_interval` setting the number of datapoints between resamples
* `n_steps_collate` setting the number of datapoints to collate activation numbers across
* `max_resamples` setting the maximum number of resamples to do before stopping