### PR TITLE
Add perplexity validation metric

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -42,6 +42,7 @@
         "jaxtyping",
         "kaiming",
         "keepdim",
+        "logit",
         "lognormal",
         "loguniform",
         "loguniformvalues",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,6 +45,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "cSpell.words": [
     "batchmean",
-    "logits"
+    "logits",
+    "roneneldan"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,9 @@
   "python.testing.pytestEnabled": true,
   "rewrap.autoWrap.enabled": true,
   "rewrap.wrappingColumn": 100,
-  "python.analysis.diagnosticMode": "workspace"
+  "python.analysis.diagnosticMode": "workspace",
+  "cSpell.words": [
+    "batchmean",
+    "logits"
+  ]
 }

--- a/sparse_autoencoder/metrics/validate/abstract_validate_metric.py
+++ b/sparse_autoencoder/metrics/validate/abstract_validate_metric.py
@@ -3,19 +3,25 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from transformer_lens import HookedTransformer
+
+from sparse_autoencoder.autoencoder.abstract_autoencoder import AbstractAutoencoder
+from sparse_autoencoder.source_data.abstract_dataset import SourceDataset
+
 
 @dataclass
-class ValidationMetricData:
+class ValidationMetricContext:
     """Validation metric data."""
 
-    source_model_loss: float
-
-    autoencoder_loss: float
+    autoencoder: AbstractAutoencoder
+    source_model: HookedTransformer
+    dataset: SourceDataset
+    hook_point: str
 
 
 class AbstractValidationMetric(ABC):
     """Abstract validation metric."""
 
     @abstractmethod
-    def calculate(self, data: ValidationMetricData) -> dict[str, Any]:
+    def calculate(self, context: ValidationMetricContext) -> dict[str, Any]:
         """Calculate any metrics."""

--- a/sparse_autoencoder/metrics/validate/perplexity_metric.py
+++ b/sparse_autoencoder/metrics/validate/perplexity_metric.py
@@ -6,11 +6,13 @@ import torch
 from torch import Tensor
 from transformer_lens.hook_points import HookPoint
 
-from sparse_autoencoder.autoencoder.abstract_autoencoder import \
-    AbstractAutoencoder
+from sparse_autoencoder.autoencoder.abstract_autoencoder import AbstractAutoencoder
 from sparse_autoencoder.metrics.validate.abstract_validate_metric import (
-    AbstractValidationMetric, ValidationMetricContext)
+    AbstractValidationMetric,
+    ValidationMetricContext,
+)
 from sparse_autoencoder.train.utils import get_model_device
+
 
 N_BATCHES = 100
 
@@ -43,16 +45,10 @@ class PerplexityMetric(AbstractValidationMetric):
 
         with torch.no_grad():
             for batch_raw in context.dataset:
-                batch = torch.tensor(batch_raw["input_ids"]).to(device=device).to(torch.int64)[:2]
-                print(batch.shape)
+                batch = torch.tensor(batch_raw["input_ids"]).to(device=device).to(torch.int64)
 
                 # Get the activations from the model
                 sae_hook = make_autoencoder_hook(context.autoencoder)
-                # standard_loss2 = context.source_model.run_with_hooks(batch, return_type="loss")
-                # sae_loss2 = context.source_model.run_with_hooks(
-                #     batch, return_type="loss", fwd_hooks=[(context.hook_point, sae_hook)]
-                # )
-
                 standard_logits = context.source_model.run_with_hooks(batch, return_type="logits")
                 sae_logits = context.source_model.run_with_hooks(
                     batch, return_type="logits", fwd_hooks=[(context.hook_point, sae_hook)]
@@ -66,22 +62,17 @@ class PerplexityMetric(AbstractValidationMetric):
                 kl_divergence = kl_divergence / batch.shape[0]
                 # loss should be equal to the negative log likelihood
                 sae_logit_outputs = sae_logits[:, :-1].reshape(-1, sae_logits.shape[-1])
-                standard_logit_outputs = standard_logits[:, :-1].reshape(-1, standard_logits.shape[-1])
-                # sae_log_probs = torch.nn.functional.log_softmax(sae_logit_outputs, dim=-1)
-                standard_log_probs = torch.nn.functional.log_softmax(standard_logit_outputs, dim=-1)
+                standard_logit_outputs = standard_logits[:, :-1].reshape(
+                    -1, standard_logits.shape[-1]
+                )
 
                 targets = batch[1:]
                 criterion = torch.nn.CrossEntropyLoss()
-                nll_loss = torch.nn.NLLLoss()
-                targets2 = torch.tensor(targets[0].item()).to(device=device).to(torch.int64).unsqueeze(0)
-                print(criterion(sae_logit_outputs, targets2))
-                print(criterion(sae_logit_outputs, targets))
 
-                sae_loss = criterion(sae_logit_outputs, targets)
-                standard_loss = torch.nn.functional.nll_loss(
-                    standard_log_probs, targets, reduction="mean"
-                )
-                breakpoint()
+                sae_loss = criterion(
+                    sae_logit_outputs, targets * 1
+                )  # multiplication by 1 fixes an unknown mps problem
+                standard_loss = criterion(standard_logit_outputs, targets * 1)
 
                 total_standard_loss += standard_loss.item()
                 total_sae_loss += sae_loss.item()

--- a/sparse_autoencoder/metrics/validate/perplexity_metric.py
+++ b/sparse_autoencoder/metrics/validate/perplexity_metric.py
@@ -1,0 +1,91 @@
+"""Doing a periodic evaluation of the autoencoder."""
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from torch import Tensor
+from transformer_lens.hook_points import HookPoint
+
+from sparse_autoencoder.autoencoder.abstract_autoencoder import AbstractAutoencoder
+from sparse_autoencoder.metrics.validate.abstract_validate_metric import (
+    AbstractValidationMetric,
+    ValidationMetricContext,
+)
+from sparse_autoencoder.train.utils import get_model_device
+
+
+N_BATCHES = 100
+
+
+def make_autoencoder_hook(
+    autoencoder: AbstractAutoencoder
+) -> Callable[[Tensor, HookPoint], Tensor]:
+    """Make the hook that will go into the forward pass of the model."""
+
+    def autoencoder_hook(input_activations: Tensor, hook: HookPoint) -> Tensor:  # noqa: ARG001
+        """Hook to get the activations from the autoencoder."""
+        _, reconstructed_activations = autoencoder(input_activations)
+        return reconstructed_activations
+
+    return autoencoder_hook
+
+
+class PerplexityMetric(AbstractValidationMetric):
+    """Calculate the change in perplexity when using the autoencoder in the original model."""
+
+    def calculate(self, context: ValidationMetricContext) -> dict[str, Any]:
+        """Run a perplexity evaluation of the model with and without the autoencoder."""
+        total_standard_loss = 0.0
+        total_sae_loss = 0.0
+        total_kl_divergence = 0.0
+        batches = 0
+
+        device = get_model_device(context.source_model)
+
+        for batch_raw in context.dataset:
+            batch = batch_raw["input_ids"].to(device=device).to(torch.int64)
+
+            # Get the activations from the model
+            sae_hook = make_autoencoder_hook(context.autoencoder)
+            standard_loss = context.source_model.run_with_hooks(batch, return_type="loss")
+            sae_loss = context.source_model.run_with_hooks(
+                batch, return_type="loss", fwd_hooks=[(context.hook_point, sae_hook)]
+            )
+
+            standard_logits = context.source_model.run_with_hooks(batch, return_type="logits")
+            sae_logits = context.source_model.run_with_hooks(
+                batch, return_type="logits", fwd_hooks=[(context.hook_point, sae_hook)]
+            )
+
+            kl_divergence = torch.nn.functional.kl_div(
+                torch.nn.functional.log_softmax(standard_logits, dim=-1),
+                torch.nn.functional.softmax(sae_logits, dim=-1),
+                reduction="batchmean",
+            )
+            kl_divergence = kl_divergence / batch.shape[0]
+            # loss should be equal to the negative log likelihood
+            sae_logit_outputs = sae_logits[:, :-1].reshape(-1, sae_logits.shape[-1])
+            standard_logit_outputs = standard_logits[:, :-1].reshape(-1, standard_logits.shape[-1])
+            sae_log_probs = torch.nn.functional.log_softmax(sae_logit_outputs, dim=-1)
+            standard_log_probs = torch.nn.functional.log_softmax(standard_logit_outputs, dim=-1)
+
+            targets = batch[:, 1:].reshape(-1)
+            sae_loss = torch.nn.functional.nll_loss(sae_log_probs, targets, reduction="mean")
+            standard_loss = torch.nn.functional.nll_loss(
+                standard_log_probs, targets, reduction="mean"
+            )
+
+            total_standard_loss += standard_loss.item()
+            total_sae_loss += sae_loss.item()
+
+            total_kl_divergence += kl_divergence.item()
+
+            batches += 1
+            if batches >= N_BATCHES:
+                break
+
+        return {
+            "Standard loss": total_standard_loss / batches,
+            "SAE loss": total_sae_loss / batches,
+            "KL divergence": total_kl_divergence / batches,
+        }

--- a/sparse_autoencoder/metrics/validate/tests/test_perplexity_metric.py
+++ b/sparse_autoencoder/metrics/validate/tests/test_perplexity_metric.py
@@ -1,0 +1,44 @@
+"""Test the perplexity metric."""
+import numpy as np
+import torch
+from transformer_lens import HookedTransformer
+from transformers import PreTrainedTokenizerBase
+
+from sparse_autoencoder.autoencoder.model import SparseAutoencoder
+from sparse_autoencoder.metrics.validate.abstract_validate_metric import ValidationMetricContext
+from sparse_autoencoder.metrics.validate.perplexity_metric import PerplexityMetric
+from sparse_autoencoder.source_data.text_dataset import GenericTextDataset
+from sparse_autoencoder.train.utils import get_model_device
+
+
+def test_perplexity_metric_with_identity() -> None:
+    """Test the perplexity metric."""
+    src_model_name = "tiny-stories-1M"
+    src_model = HookedTransformer.from_pretrained(src_model_name, dtype="float32")
+    src_mlp_width: int = src_model.cfg.d_mlp  # type: ignore
+
+    device = get_model_device(src_model)
+
+    tokenizer: PreTrainedTokenizerBase = src_model.tokenizer  # type: ignore
+    source_data = GenericTextDataset(tokenizer=tokenizer, dataset_path="roneneldan/TinyStories")
+
+    autoencoder = SparseAutoencoder(
+        n_input_features=src_mlp_width,
+        n_learned_features=src_mlp_width,
+        geometric_median_dataset=torch.zeros(src_mlp_width),
+    ).to(device=device)
+    autoencoder.encoder.weight.data = torch.eye(src_mlp_width).to(device=device)
+    autoencoder.decoder.weight.data = torch.eye(src_mlp_width).to(device=device)
+    autoencoder.encoder.bias.data = torch.zeros(src_mlp_width).to(device=device)
+
+    context = ValidationMetricContext(
+        autoencoder=autoencoder,
+        source_model=src_model,
+        dataset=source_data,
+        hook_point="blocks.1.mlp.hook_post",
+    )
+
+    perplexity_metric = PerplexityMetric()
+    results = perplexity_metric.calculate(context)  # type: ignore
+    assert np.isclose(results["SAE loss"], results["Standard loss"], atol=1e-4)
+    assert np.isclose(results["KL divergence"], 0.0, atol=1e-4)

--- a/sparse_autoencoder/train/pipeline.py
+++ b/sparse_autoencoder/train/pipeline.py
@@ -8,6 +8,7 @@ import wandb
 
 from sparse_autoencoder.activation_store.tensor_store import TensorActivationStore
 from sparse_autoencoder.metrics.train.abstract_train_metric import TrainMetricData
+from sparse_autoencoder.metrics.validate.abstract_validate_metric import ValidationMetricContext
 from sparse_autoencoder.source_model.store_activations_hook import store_activations_hook
 from sparse_autoencoder.tensor_types import BatchTokenizedPrompts, NeuronActivity
 from sparse_autoencoder.train.abstract_pipeline import AbstractPipeline
@@ -126,7 +127,11 @@ class Pipeline(AbstractPipeline):
 
         return learned_activations_fired_count
 
-    def validate_sae(self) -> None:
+    def validate_sae(self, context: ValidationMetricContext) -> None:
         """Get validation metrics."""
-        # Not currently setup
-        return
+        validation_metrics = {}
+        for metric in self.metrics.validation_metrics:
+            calculated = metric.calculate(context)
+            validation_metrics.update(calculated)
+
+        wandb.log(data=validation_metrics, step=self.total_training_steps, commit=True)


### PR DESCRIPTION
Adds the perplexity of the model with the SAE included as a validation metric, along with the the perplexity of the normal model for reference, and the KL-divergence between the standard and SAE-pass-through logits.

Results look sensible on small test runs.