### PR TITLE
Resampler interval fix

### DIFF
--- a/sparse_autoencoder/activation_resampler/activation_resampler.py
+++ b/sparse_autoencoder/activation_resampler/activation_resampler.py
@@ -335,7 +335,7 @@ class ActivationResampler(AbstractActivationResampler):
         """Step the resampler, collating neuron activity and resampling if necessary.
 
         Args:
-            last_resampled: Last time the resampler was run.
+            last_resampled: Last step at which the resampler was run.
             batch_neuron_activity: Number of times each neuron fired in the current batch.
             activation_store: Activation store.
             autoencoder: Sparse autoencoder model.
@@ -361,7 +361,7 @@ class ActivationResampler(AbstractActivationResampler):
         self.collated_neuron_activity_vectors_count += train_batch_size
 
         # Check if we should resample.
-        if last_resampled % self.resample_interval != 0:
+        if last_resampled < self.resample_interval:
             return None
 
         # Resample

--- a/sparse_autoencoder/autoencoder/components/linear_encoder.py
+++ b/sparse_autoencoder/autoencoder/components/linear_encoder.py
@@ -82,7 +82,7 @@ class LinearEncoder(AbstractEncoder):
         self._bias = Parameter(torch.zeros(learnt_features))
         self.activation_function = ReLU()
 
-        self.reset_param_names: list[ParameterAxis] = [(self._weight, 0), (self._bias, 1)]
+        self.reset_param_names: list[ParameterAxis] = [(self._weight, 0), (self._bias, 0)]
 
         self.reset_parameters()
 


### PR DESCRIPTION
(My) resampling logic was wrong, and only passed tests because it assumed that resample_interval % batch_size == 0, which was true for our testing, have added a test that the previous version would have failed.

Highlights the need for a resampler test that tests the whole section end to end.