### PR TITLE
Change reconstruction score to use change in means.

### DIFF
--- a/sparse_autoencoder/metrics/validate/model_reconstruction_score.py
+++ b/sparse_autoencoder/metrics/validate/model_reconstruction_score.py
@@ -9,6 +9,7 @@ from sparse_autoencoder.metrics.validate.abstract_validate_metric import (
 
 if TYPE_CHECKING:
     from sparse_autoencoder.tensor_types import Axis
+
 from jaxtyping import Float
 from torch import Tensor
 
@@ -63,10 +64,10 @@ class ModelReconstructionScore(AbstractValidationMetric):
         zero_ablate_loss_minus_reconstruction_loss: Float[Tensor, Axis.ITEMS] = (
             data.source_model_loss_with_zero_ablation - data.source_model_loss_with_reconstruction
         )
-        model_reconstruction_score_itemwise: Float[Tensor, Axis.ITEMS] = (
-            zero_ablate_loss_minus_reconstruction_loss / zero_ablate_loss_minus_default_loss
+        model_reconstruction_score: float = (
+            zero_ablate_loss_minus_reconstruction_loss.mean().item()
+            / zero_ablate_loss_minus_default_loss.mean().item()
         )
-        model_reconstruction_score: float = model_reconstruction_score_itemwise.mean().item()
 
         # Get the other metrics
         validation_baseline_loss: float = data.source_model_loss.mean().item()

--- a/sparse_autoencoder/metrics/validate/tests/test_model_reconstruction_score.py
+++ b/sparse_autoencoder/metrics/validate/tests/test_model_reconstruction_score.py
@@ -42,7 +42,7 @@ def test_model_reconstruction_score_empty_data() -> None:
                 source_model_loss_with_reconstruction=Float[Tensor, Axis.ITEMS]([1.5, 2.5, 3.5]),
                 source_model_loss_with_zero_ablation=Float[Tensor, Axis.ITEMS]([8.0, 7.0, 4.0]),
             ),
-            0.67,
+            0.79,
         ),
     ],
 )


### PR DESCRIPTION
The current method of calculating takes the average of the case-by-case reconstruction score.

This seems wrong because it divides by the difference between the zero-ablation loss and the source loss which in some cases will be very close to zero, especially with models with more layers, and these cases will get large weight. Taking the average difference in loss seems more principled to me. 

PR also changes the corresponding test.

Would like to test it to check that it reduces the noise but getting annoying wandb errors `"message":"Invalid sweep config: invalid hyperparameter configuration: source_data"` at the moment.