### PR TITLE
Handling StopIteration error while generate activations

### DIFF
--- a/sparse_autoencoder/train/pipeline.py
+++ b/sparse_autoencoder/train/pipeline.py
@@ -175,6 +175,8 @@ class Pipeline:
             hook = partial(store_activations_hook, store=store, component_idx=component_idx)
             self.source_model.add_hook(cache_name, hook)
 
+        print("Generate Process Begin")
+
         # Loop through the dataloader until the store reaches the desired size
         with torch.no_grad():
             while len(store) < store_size:

--- a/sparse_autoencoder/train/pipeline.py
+++ b/sparse_autoencoder/train/pipeline.py
@@ -177,8 +177,6 @@ class Pipeline:
             hook = partial(store_activations_hook, store=store, component_idx=component_idx)
             self.source_model.add_hook(cache_name, hook)
 
-        print("Generate Process Begin")
-
         # Loop through the dataloader until the store reaches the desired size
         with torch.no_grad():
             while len(store) < store_size:

--- a/sparse_autoencoder/train/pipeline.py
+++ b/sparse_autoencoder/train/pipeline.py
@@ -1,6 +1,8 @@
 """Default pipeline."""
 from collections.abc import Iterator
 from functools import partial
+
+import itertools
 import logging
 from pathlib import Path
 from tempfile import gettempdir
@@ -139,7 +141,7 @@ class Pipeline:
         source_dataloader = source_dataset.get_dataloader(
             source_data_batch_size, num_workers=num_workers_data_loading
         )
-        self.source_data = iter(source_dataloader)
+        self.source_data = itertools.cycle(source_dataloader)
 
     @validate_call
     def generate_activations(self, store_size: PositiveInt) -> TensorActivationStore:


### PR DESCRIPTION
There may be a StopIteration error depending on the source dataset. To bypass this error, use itertools.cycle.