### PR TITLE
fix import renaming on python 2.2.0

### DIFF
--- a/sparse_autoencoder/optimizer/adam_with_reset.py
+++ b/sparse_autoencoder/optimizer/adam_with_reset.py
@@ -8,7 +8,8 @@ from jaxtyping import Float, Int
 from torch import Tensor
 from torch.nn.parameter import Parameter
 from torch.optim import Adam
-from torch.optim.optimizer import params_t
+try: from torch.optim.optimizer import params_t
+except ImportError: from torch.optim.optimizer import ParamsT as params_t
 
 from sparse_autoencoder.tensor_types import Axis
 


### PR DESCRIPTION
params_t was renamed to ParamsT in 2.2